### PR TITLE
Replace deployable code check in test/live section with wait until progress completion

### DIFF
--- a/src/Commands/SitePushUpdateCommand.php
+++ b/src/Commands/SitePushUpdateCommand.php
@@ -160,11 +160,18 @@ class SitePushUpdateCommand extends TerminusCommand implements SiteAwareInterfac
                         '{site}: {env} deploying updates',
                         ['site' => $data['name'], 'env' => $current_env]
                       );
-                      $env->deploy([
+                      $workflow = $env->deploy([
                         'updatedb' => !$options['skip_updatedb'],
                         'clear_cache' => 1,
                         'annotation' => $options['message']
                       ]);
+                      $progress = new ProgressBar($output);
+                      $progress->setFormat('[%bar%] %elapsed:6s% %memory:6s%');
+                      $progress->start();
+                      while (!$workflow->checkProgress()) {
+                        $progress->advance();
+                      }
+                      $progress->finish();
                     }else{
                       $this->log()->notice(
                         '{site}: {env} has no deployable code',

--- a/src/Commands/SitePushUpdateCommand.php
+++ b/src/Commands/SitePushUpdateCommand.php
@@ -155,29 +155,22 @@ class SitePushUpdateCommand extends TerminusCommand implements SiteAwareInterfac
                     }
                 } else {
                     $env = $site->getEnvironments()->get($current_env);
-                    if ($env->hasDeployableCode()) {
-                      $this->log()->notice(
-                        '{site}: {env} deploying updates',
-                        ['site' => $data['name'], 'env' => $current_env]
-                      );
-                      $workflow = $env->deploy([
-                        'updatedb' => !$options['skip_updatedb'],
-                        'clear_cache' => 1,
-                        'annotation' => $options['message']
-                      ]);
-                      $progress = new ProgressBar($output);
-                      $progress->setFormat('[%bar%] %elapsed:6s% %memory:6s%');
-                      $progress->start();
-                      while (!$workflow->checkProgress()) {
-                        $progress->advance();
-                      }
-                      $progress->finish();
-                    }else{
-                      $this->log()->notice(
-                        '{site}: {env} has no deployable code',
-                        ['site' => $data['name'], 'env' => $current_env]
-                      );
+                    $this->log()->notice(
+                      '{site}: {env} deploying updates',
+                      ['site' => $data['name'], 'env' => $current_env]
+                    );
+                    $workflow = $env->deploy([
+                      'updatedb' => !$options['skip_updatedb'],
+                      'clear_cache' => 1,
+                      'annotation' => $options['message']
+                    ]);
+                    $progress = new ProgressBar($output);
+                    $progress->setFormat('[%bar%] %elapsed:6s% %memory:6s%');
+                    $progress->start();
+                    while (!$workflow->checkProgress()) {
+                      $progress->advance();
                     }
+                    $progress->finish();
                 }
 
                 if ($data['framework'] == 'drupal' && !$options['skip_updatedb']) {


### PR DESCRIPTION
To address issue #7, this replaces the `hasDeployableCode()` check—at  the beginning of the test/live deployment stage of the script—with a wait for `checkProgress()` to be true, at the end of it. 

The behavior I’ve observed seems to indicate that `hasDeployableCode()` is returning a false negative.  The first thing I tried was to precede it with this:

```
for ($x = 0; $x <= 20; $x++) {
    if (!$env->hasDeployableCode()) {
      sleep(3);
    }else{
      break;
    }
  };
```

… but I found that at times the script would still wait the whole minute (well after the Pantheon dashboard indicated that a deploy was available). It's as if this check will either pass immediately, or fail forever (unless you run the whole command again, then it's fine? 🤷‍♂️)

So what I've done is remove that check entirely, and add a loop to checkProgress() instead.